### PR TITLE
Replace the ostensibly deprecated 'env' parameter with 'deployment'

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   - BITRISE_STEP_ID: appcenter-codepush-release-react-native
-  - BITRISE_STEP_VERSION: 0.0.1
+  - BITRISE_STEP_VERSION: 0.0.2
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/adrianchinghc/bitrise-step-appcenter-codepush-release-react-native.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/adrianchinghc/bitrise-steplib.git
 

--- a/step.sh
+++ b/step.sh
@@ -19,6 +19,6 @@ if [ ! -z "${react_native_project_root}" ] ; then
     fi
 fi
 
-appcenter codepush release-react -a $app_id --token $api_token --quiet $options --env $env
+appcenter codepush release-react -a $app_id --token $api_token --quiet $options --deployment $deployment
 
 exit 0

--- a/step.sh
+++ b/step.sh
@@ -19,6 +19,6 @@ if [ ! -z "${react_native_project_root}" ] ; then
     fi
 fi
 
-appcenter codepush release-react -a $app_id --token $api_token --quiet $options --deployment $deployment
+appcenter codepush release-react -a $app_id --token $api_token --quiet $options --deployment-name $deployment
 
 exit 0

--- a/step.yml
+++ b/step.yml
@@ -56,13 +56,13 @@ inputs:
         AppCenter API Token can be obtained from [here]](https://appcenter.ms/settings/apitokens).
         New API Token > Enter a description for the token > Select Full Access > Add New API Token
       is_required: true
-  - env: 'prod'
+  - deployment: 'Production'
     opts:
-      title: Environment
+      title: Deployment
       description: |
-        Choices for environments [here](https://github.com/Microsoft/appcenter-cli/blob/61bd72c1dcabeb876ee14fcaa316fd6b367b49a6/src/commands/codepush/lib/environment.ts#L18)
+        Default deployments are `Staging` and `Production`. See [here](https://docs.microsoft.com/en-us/appcenter/distribution/codepush/cli#deployment-management) for details.
       is_required: true
-  - options: 
+  - options:
     opts:
       title: Extra Options
       description: |


### PR DESCRIPTION
appcenter-cli no longer seems to use the `--env` parameter; it appears to have been superseded by `--deployment` which specifies to which 'Deployment' a codepush bundle should be delivered.

Accordingly, this PR replaces the deprecated (unless it's used secretly somewhere I didn't see) `env` parameter with `deployment`.